### PR TITLE
fix: get file version for cloud shared models

### DIFF
--- a/revit_extract/RevitExtractor.py
+++ b/revit_extract/RevitExtractor.py
@@ -69,10 +69,10 @@ class RevitExtractor:
         with olefile.OleFileIO(rvt_file) as rvt_ole:
             bfi = rvt_ole.openstream("BasicFileInfo")
             file_info = bfi.read().decode("utf-16le", "ignore")
-            pattern = re.compile(r"\d{4}")
+            pattern = r"\x04\x00(\d{4})"
             match = re.search(pattern, file_info)
             if match:
-                return match.group(0)
+                return match.group(1)
             else:
                 print("No version found in file info.")
                 return None


### PR DESCRIPTION
Hi Choung, 

Tried this one on files today and there is a little issue with getting the version of Revit in cloud workshared models (downloaded to local).

For example, a local model when read will show a file_info = '\x0e\x00\x00\x00\x00\x00\x00**\x04\x002022**\x12\x0020240704_1515(x64)L\x00C:\\test_data\\2022_Project.rvt\  ... etc

while a workshared one will show this:

file_info = '\x0e\x00\x01\x00\x00J\x00Autodesk Docs://123304safd63-project_name.rvt**\x04\x002023**\x12\x0020230828_1515(x64)J\x00Autodesk Docs:// ... etc

As you can see, the default 4 digits regex check will fail in the workshared case as a project number, very usual, will be picked up first.

I suggest the new regex pattern that will pick the version no matter how the model is setup, as marked in bold in the previous examples.

Let me know what you think, I was going to open an issue, but solved this one rather quickly, so here is the PR.

